### PR TITLE
using "-enddate" saves one grep

### DIFF
--- a/mx-ssl-linux.sh
+++ b/mx-ssl-linux.sh
@@ -25,7 +25,7 @@ if [ "$#" -le "0" ]; then
 			echo ""
 			for server in $mx
 				do
-					date2=$(echo quit |openssl s_client -starttls smtp -connect "$server":25 2>/dev/null | openssl x509 -noout -dates | grep notAfter |cut -d"=" -f2) 			## get SSL expiry date from TLS connection
+					date2=$(echo quit |openssl s_client -starttls smtp -connect "$server":25 2>/dev/null | openssl x509 -noout -enddate |cut -d"=" -f2) 			## get SSL expiry date from TLS connection
 					exp_date_smtp=$(date -d "$date2" +"%s") 		## convert expiry date timestamp to seconds
 					echo "scale=0; ($exp_date_smtp - $cur_date) / 86400" |bc -l			## calculate expiry time and convert result to days
 			done

--- a/mx-ssl.sh
+++ b/mx-ssl.sh
@@ -4,7 +4,7 @@
 ## uwe@usommer.de
 ## 01/2018
 
-## todo: 
+## todo:
 ## more error checks
 ## display complete TLS analysis
 
@@ -13,7 +13,7 @@ if [ "$#" -le "0" ]; then
 		else
 			domain="$1"
 			cur_date=$(date +%s)														## convert current date to seconds (Epoch time)
-			mx=$(dig +short mx "$domain" | awk '{print $2}') 							## get mx records and read hosts
+			mx=$(dig +short mx "$domain" | awk '{print $2}')							## get mx records and read hosts
 			echo "remaining days for SSL certificates on Mailservers"
 			echo ""
 			echo "Domain: $domain"
@@ -25,8 +25,8 @@ if [ "$#" -le "0" ]; then
 			echo ""
 			for server in $mx
 				do
-					date2=$(echo quit |openssl s_client -starttls smtp -connect "$server":25 2>/dev/null | openssl x509 -noout -dates | grep notAfter |cut -d"=" -f2) 			## get SSL expiry date from TLS connection
-					exp_date_smtp=$(date -j -f "%b %d %T %Y %Z" "$date2" +"%s") 		## convert expiry date timestamp to seconds
+					date2=$(echo quit |openssl s_client -starttls smtp -connect "$server":25 2>/dev/null | openssl x509 -noout -enddate |cut -d"=" -f2)			## get SSL expiry date from TLS connection
+					exp_date_smtp=$(date -j -f "%b %d %T %Y %Z" "$date2" +"%s")		## convert expiry date timestamp to seconds
 					echo "scale=0; ($exp_date_smtp - $cur_date) / 86400" |bc -l			## calculate expiry time and convert result to days
 			done
 fi


### PR DESCRIPTION
Hi Uwe,

using "-enddate" on the openssl command will save one grep and make it a little simpler. Seems to work even on older openssl/libressl